### PR TITLE
Fcpw improve job scheduling

### DIFF
--- a/src/windows/dienstplan.php
+++ b/src/windows/dienstplan.php
@@ -23,14 +23,15 @@ if( $action ) {
   }
 }
 
-get_http_var("startdatum_day",'U',0);
-get_http_var("startdatum_month",'U',0);
-get_http_var("startdatum_year",'U',0);
-get_http_var("dienstinterval","U",7) or $dienstinterval = 7;
-get_http_var("dienstanzahl","U",8) or $dienstanzahl = 8;
-get_http_var("personen_1","u",2) or $personen_1 = 2;
-get_http_var("personen_3","u",2) or $personen_3 = 2;
-get_http_var("personen_4","u",2) or $personen_4 = 2;
+get_http_var("startdatum_day"  , 'U', 0);
+get_http_var("startdatum_month", 'U', 0);
+get_http_var("startdatum_year" , 'U', 0);
+get_http_var("dienstinterval"  , "U", 7) or $dienstinterval = 7;
+get_http_var("dienstanzahl"    , "U", 8) or $dienstanzahl = 8;
+get_http_var("personen_1"      , "u", 2) or $personen_1 = 2;
+get_http_var("personen_3"      , "u", 2) or $personen_3 = 2;
+get_http_var("personen_4"      , "u", 2) or $personen_4 = 2;
+get_http_var("useRotation"     , "u", 0);
 
 if( $startdatum_day && $startdatum_month && $startdatum_year ) {
   $startdatum = "$startdatum_year-$startdatum_month-$startdatum_day";
@@ -170,6 +171,12 @@ if( hat_dienst(5) ) {
             open_span( 'medskip', '', "{$dienstinfos[4]['label']}: " . int_view( $personen_4, "personen_4", 1 ) . " Personen<br>" );
             open_span( 'medskip', '', "{$dienstinfos[3]['label']}: " . int_view( $personen_3, "personen_3", 1 ) . " Personen<br>" );
             open_span( 'medskip', '', "{$dienstinfos[1]['label']}: " . int_view( $personen_1, "personen_1", 1 ) . " Personen<br>" );
+        open_tr();
+          open_td( 'qquad' );
+          smallskip();
+          echo
+            '<input type="checkbox" class="checkbox" name="useRotation" value="1">' .
+              'Rotationsplan für Vorschläge nutzen';
         open_tr();
           open_td( 'right', '' );
             smallskip();

--- a/src/windows/dienstplan.php
+++ b/src/windows/dienstplan.php
@@ -29,7 +29,7 @@ get_http_var("startdatum_year",'U',0);
 get_http_var("dienstinterval","U",7) or $dienstinterval = 7;
 get_http_var("dienstanzahl","U",8) or $dienstanzahl = 8;
 get_http_var("personen_1","u",2) or $personen_1 = 2;
-get_http_var("personen_3","u",1) or $personen_3 = 1;
+get_http_var("personen_3","u",2) or $personen_3 = 2;
 get_http_var("personen_4","u",2) or $personen_4 = 2;
 
 if( $startdatum_day && $startdatum_month && $startdatum_year ) {

--- a/src/windows/dienstplan.php
+++ b/src/windows/dienstplan.php
@@ -291,7 +291,7 @@ open_table( 'list' );
               smallskip();
             $dienst = next( $dienste );
           }
-          if( hat_dienst(5) && ! $readonly && ! $dienst['historic'] ) {
+          if( hat_dienst(5) && ! $readonly && ! ($dienst && $dienst['historic']) ) {
             open_tr();
             open_td( 'smallskip center', '',
               fc_action(

--- a/src/windows/gruppen.php
+++ b/src/windows/gruppen.php
@@ -90,7 +90,7 @@ switch( $action ) {
     // echo "id: $gruppen_id, trans: $transaction_id <br>";
     $trans = sql_get_transaction( -$transaction_id );
     if( $trans['gruppen_id'] != $login_gruppen_id )
-      nur_fuer_dienst(4,5);
+      nur_fuer_dienst(5);
     need( $trans['konterbuchung_id'] == 0, 'bereits verbucht, kann nicht mehr gelöscht werden!' );
     doSql( "DELETE FROM gruppen_transaktion WHERE id=$transaction_id" );
     break;


### PR DESCRIPTION
The default behaviour for adding new job schedule entries has changed as follows:

- by default, open job slots are created (before: job slots were pre-filled using the rotation plan)
- in order to get the result that used to be default, a new checkbox has been added ("use rotation plan")

As the rotation plan is not used by our FC at all, the pre-filled slots were considered an anti-feature (because it was necessary to always delete the pre-filled slots and create open ones manually in order to get the desired result)