### PR TITLE
feat: add button to toggle basar order mode

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -14,7 +14,7 @@ COMMIT=`git rev-parse --short HEAD`
 COMMIT_FULL=`git rev-parse HEAD`
 DIRTY=""
 wd_clean || DIRTY='-dirty'
-echo "<a rel="noreferrer noopener" target="_blank" href='http://github.com/fcpotsdamwest/foodsoft/commit/$COMMIT_FULL'>$BRANCH-$COMMIT$DIRTY</a>" >src/version.txt
+echo "<a rel='noreferrer noopener' target='_blank' href='http://github.com/fcpotsdamwest/foodsoft/commit/$COMMIT_FULL'>$BRANCH-$COMMIT$DIRTY</a>" >src/version.txt
 
 chmod 644 .gitattributes
 chmod 644 .gitignore
@@ -24,7 +24,7 @@ chmod 644 README.md
 chmod 644 ToDo.txt
 chmod 644 apache.sample.conf
 chmod 644 db/mwst.sql
-chmod 755 deploy.sh
+chmod 700 deploy.sh
 chmod 644 dev/.env.sample
 chmod 644 dev/db/config/foodsoft.cnf
 chmod 644 dev/docker-compose.yml

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -18,7 +18,7 @@ COMMIT=`git rev-parse --short HEAD`
 COMMIT_FULL=`git rev-parse HEAD`
 DIRTY=""
 wd_clean || DIRTY='-dirty'
-echo "<a rel="noreferrer noopener" target="_blank" href='http://github.com/fcpotsdamwest/foodsoft/commit/$COMMIT_FULL'>$BRANCH-$COMMIT$DIRTY</a>" >src/version.txt
+echo "<a rel='noreferrer noopener' target='_blank' href='http://github.com/fcpotsdamwest/foodsoft/commit/$COMMIT_FULL'>$BRANCH-$COMMIT$DIRTY</a>" >src/version.txt
 
 EOF
   git ls-files | xargs stat -c "chmod %a %n"

--- a/src/code/zuordnen.php
+++ b/src/code/zuordnen.php
@@ -4341,6 +4341,7 @@ $foodsoft_get_vars = array(
   'auszug_jahr' => 'u',
   'auszug_nr' => 'u',
   'auszus_jahr' => 'u',
+  'basarmodus' => '/[01]/',
   'bestell_id' => 'u',
   'buchung_id' => 'd' /* kann auch negativ sein */,
   'confirmed' => 'w',

--- a/src/windows/bestellen.php
+++ b/src/windows/bestellen.php
@@ -5,25 +5,46 @@ assert( $angemeldet ) or exit();
 
 setWikiHelpTopic( "foodsoft:bestellen" );
 
+get_http_var( 'basarmodus', 'd', 0, true);
+get_http_var( 'bestell_id','u',false,true );
 get_http_var( 'vertical_scroll', 'w', '' );
 
-if( hat_dienst(4) ) {
-  $gruppen_id = $basar_id;
+// variable muss evtl. an anderen Stellen mitübergeben werden, wie dem Link auf "abbrechen" im floating submit Button
+
+if( hat_dienst(4) && $basarmodus ) {
+  $gruppen_id = $basar_id; // Im Basarmodus wird für den Basar bestellt...
   $kontostand = 250.0;
   $festgelegt = 0.0;
-  echo "<h1>Bestellen für den Basar</h1>";
+  $heading = "Bestellen für den Basar";
 } else {
-  $gruppen_id = $login_gruppen_id;  // ...alle anderen für sich selbst!
+  $gruppen_id = $login_gruppen_id;  // ...ansonsten für sich selbst!
   $kontostand = kontostand( $gruppen_id );
   // $festgelegt = gruppenkontostand_festgelegt( $gruppen_id );
-  echo "<h1>Bestellen für Gruppe $login_gruppen_name</h1>";
+  $heading = "Bestellen für Gruppe $login_gruppen_name";
 }
 
-get_http_var('bestell_id','u',false,true );
-if( $bestell_id ) {
-  if( sql_bestellung_status( $bestell_id ) != STATUS_BESTELLEN )
-    $bestell_id = 0;
-}
+if ( hat_dienst(4) ) { // add button to toggle basar/group order
+  $basarToggleUrl = fc_link(
+    'self',
+    [
+      'bestell_id' => $bestell_id ?: 0,
+      'basarmodus' => -($basarmodus-1), // 0 => 1, 1 => 0
+      'context' => 'js',
+      ]
+    );
+    $orderFor = $basarmodus
+      ? "Gruppe $login_gruppen_name"
+      : "den Basar";
+    $basarToggleButton = "<button id='basarToggleButton' onClick=\"$basarToggleUrl\" style='display:inline'>Für $orderFor bestellen</button>";
+    $heading .= "&nbsp;$basarToggleButton";
+  }
+  
+  echo "<h1>$heading</h1>";
+  
+  if( $bestell_id ) {
+    if( sql_bestellung_status( $bestell_id ) != STATUS_BESTELLEN )
+      $bestell_id = 0;
+  }
 
 $laufende_bestellungen = sql_bestellungen( 'rechnungsstatus = ' . STATUS_BESTELLEN );
 if( count( $laufende_bestellungen ) < 1) {
@@ -388,6 +409,11 @@ if( ! $readonly ) {
       return true;
     }
 
+    function disable_basar_toggle() {
+      const basarToggleButton = document.getElementById('basarToggleButton');
+      basarToggleButton.disabled = true;
+    }
+
     function reminder_on() {
       const reminder = document.getElementById('floating_submit_button_<?php echo $bestellform_id; ?>');
       const footbar = document.getElementById('footbar');
@@ -398,6 +424,7 @@ if( ! $readonly ) {
       footbar.appendChild(reminder);
       
       set_footbar(true);
+      disable_basar_toggle();
       
       const id = document.getElementById('hinzufuegen');
       while( id.firstChild ) {


### PR DESCRIPTION
The previous default of having users logged
in as "dienst 4" order for the basar used to
cause confusion, so this changes the
default to group order mode and provides a
dedicated button to toggle to basar mode.