### PR TITLE
fix: update bulletin board text truncation logic

### DIFF
--- a/src/css/foodsoft.css
+++ b/src/css/foodsoft.css
@@ -1143,6 +1143,7 @@ div.board {
 
 div.board textarea {
   border-style: none;
+  resize: none;
 }
 
 .chalk {

--- a/src/windows/menu.php
+++ b/src/windows/menu.php
@@ -3,24 +3,28 @@
 setWikiHelpTopic( 'foodsoft:' );
 
 get_http_var( 'action', 'w', '' );
+
 if( $readonly )
-  $action = '';
+    $action = '';
+
 $ro_tag = 'readonly';
+
 switch( $action ) {
-  case 'edit':
-    $ro_tag = '';
-    break;
-  case 'save':
-    need_http_var( 'bulletinboard', 'H' );
-    $b = preg_split( '/\n/m', $bulletinboard . "\n\n\n\n\n\n\n" );
-    $bulletinboard = '';
-    $nl = '';
-    for( $i = 0; $i <= 7; ++$i ) {
-      $bulletinboard .= ( $nl . rtrim( preg_replace( '/\r/', '', $b[$i] ) ) );
-      $nl = "\n";
-    }
-    sql_update( 'leitvariable', array( 'name'=> 'bulletinboard' ), array( 'value' => $bulletinboard ) );
-    break;
+    case 'edit':
+        $ro_tag = '';
+        break;
+    case 'save':
+        need_http_var( 'bulletinboard', 'H' );
+        # truncate borard text to 12 lines and normalize line endings
+        $b = preg_split( '/\n/m', $bulletinboard );
+        $bulletinboard = '';
+        $nl = '';
+        for( $i = 0; $i <= 11; ++$i ) {
+            $bulletinboard .= ( $nl . rtrim( preg_replace( '/\r/', '', $b[$i] ) ) );
+            $nl = "\n";
+        }
+        sql_update( 'leitvariable', array( 'name'=> 'bulletinboard' ), array( 'value' => $bulletinboard ) );
+        break;
 }
 
 open_table( 'layout hfill' );


### PR DESCRIPTION
Keep as many lines as the displayed size of the board has
(this wasn't updated when the board was resized to adjust for 2020 screen resolutions)