### PR TITLE
feat: lazy-load older/less-relevant data for orders and jobs

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -114,7 +114,7 @@ chmod 644 src/windows/editProdukt.php
 chmod 644 src/windows/editProduktgruppe.php
 chmod 644 src/windows/editVerpackung.php
 chmod 644 src/windows/gesamtlieferschein.php
-chmod 664 src/windows/gruppen.php
+chmod 644 src/windows/gruppen.php
 chmod 644 src/windows/gruppenkonto.php
 chmod 644 src/windows/gruppenmitglieder.php
 chmod 644 src/windows/gruppenpfand.php

--- a/src/code/zuordnen.php
+++ b/src/code/zuordnen.php
@@ -2102,6 +2102,20 @@ function sql_bestellung( $bestell_id ) {
   return current($r);
 }
 
+/**
+ * Returns the timestamp of the oldest order that is not yet cleared
+ */
+function sql_bestellung_oldest_unfinished_timestamp() {
+  return sql_select_single_field(
+    "
+    SELECT UNIX_TIMESTAMP(`lieferung`) AS unfinished
+    FROM gesamtbestellungen
+    WHERE `rechnungsstatus` < " . STATUS_ABGERECHNET . " 
+    ORDER BY `lieferung` ASC
+    LIMIT 1
+    ", 'unfinished');
+}
+
 
 /* function select_gesamtbestellungen_schuldverhaeltnis():
  *  liefert gesamtbestellungen, für die bereits ein verbindlicher vertrag besteht
@@ -4647,6 +4661,7 @@ $foodsoft_get_vars = array(
   'prev_id' => 'u',
   'produkt_id' => 'u',
   'ro' => 'u',
+  'since' => 'U',
   'spalten' => 'u',
   'state' => 'u',
   'transaktion_id' => 'u',

--- a/src/js/foodsoft.js
+++ b/src/js/foodsoft.js
@@ -634,3 +634,20 @@ var SearchableSelect = Class.create({
 function disableAutocomplete(element) {
   element.setAttribute('autocomplete', 'off');
 }
+
+/**
+ * Modify the value of query parameter 'parameter' by setting it to
+ * the current value (or the default value) plus delta.
+ * Finally, the page is reloaded.
+ * 
+ * @param {string} parameter 
+ * @param {number} defaultValue
+ * @param {number} delta 
+ */
+function loadMore(parameter, defaultValue, delta) {
+  const url = new URL(window.location.href);
+  const currentValue = parseInt(url.searchParams.get(parameter)) || defaultValue;
+  // increment is roughly 1y
+  url.searchParams.set(parameter, currentValue + delta);
+  window.location.href = url.toString();
+}

--- a/src/windows/bestellungen.php
+++ b/src/windows/bestellungen.php
@@ -2,6 +2,16 @@
 
 assert( $angemeldet ) or exit();
 
+// 'since' sets the lower boundary of the time period displayed (upper boundary is NOW) as Unix epoch timestamp
+get_http_var('since', 'U', -1);
+if ( $since === -1 ) {
+  // show last 2 years by default, or the datetime of the last unfinished order (if older)
+  $oldest_unfinished = sql_bestellung_oldest_unfinished_timestamp();
+  $two_years_ago = (new DateTime())->modify('-2 years')->getTimestamp(); 
+  $since = min($oldest_unfinished, $two_years_ago);
+}
+$sinceDate = (new DateTime())->setTimestamp($since)->format("Y-m-d");
+
 get_http_var( 'orderby', 'w', 'status', true );
 switch( $orderby ) {
   case 'name':
@@ -132,7 +142,7 @@ switch( $action ) {
 }
 
 
-echo "<h1 class='bigskip'>Liste aller Bestellungen</h1>";
+echo "<h1 class='bigskip'>Liste aller Bestellungen (seit {$sinceDate})</h1>";
 
 open_table( 'list hfill' );
   open_th();
@@ -151,8 +161,8 @@ open_table( 'list hfill' );
   if( hat_dienst(4) )
     open_th('','','Abrechnung');
 
-// $bestellungen = sql_bestellungen( 'true', 'rechnungsstatus, abrechnung_id DESC' );
-$bestellungen = sql_bestellungen( 'true', $order );
+$selected_since_condition = "`lieferung` > FROM_UNIXTIME({$since})";
+$bestellungen = sql_bestellungen( $selected_since_condition, $order );
 $abrechnung_id = -1;
 foreach( $bestellungen as $bestellung ) {
   $abrechnung_id = $bestellung['abrechnung_id'];
@@ -487,8 +497,22 @@ foreach( $bestellungen as $bestellung ) {
   }
 }
 close_table();
-  ?>
+
+medskip();
+
+open_div( 'center' );
+  open_tag("button", "button", "id='loadMoreButton'", "⇩⇩⇩ Mehr laden... ⇩⇩⇩");
+close_div();
+
+?>
+
   <script>
+    document.getElementById('loadMoreButton').addEventListener(
+      'click',
+      // move the limit roughly 1y back in time (-31536000s)
+      (event) => { loadMore('since', <?php echo $since ?>, -31536000); }
+    );
+
     var abrechnung_id = 0;
 
     function kombinieren( id2 ) {

--- a/src/windows/dienstplan.php
+++ b/src/windows/dienstplan.php
@@ -214,8 +214,25 @@ if( hat_dienst(5) ) {
   close_div();
 }
 
+get_http_var('since', 'U', -1);
+if ( $since === -1 ) {
+  // show last year by default
+  $one_year_ago = (new DateTime())->modify('-1 years')->getTimestamp(); 
+  $since = $one_year_ago;
+}
+$sinceDate = (new DateTime())->setTimestamp($since)->format("Y-m-d");
 
-?> <h1>Dienstliste</h1> <?php
+$title_addition = "";
+$filter_since_period = "true";
+$order = "lieferdatum ASC, dienst DESC";
+
+if ( $options & OPTION_SHOW_HISTORY ) {
+  $title_addition = " (seit {$sinceDate})";
+  $filter_since_period = "`lieferdatum` > FROM_UNIXTIME({$since})";
+  $order = "lieferdatum DESC, dienst DESC";
+}
+
+?> <h1>Dienstliste<?php echo $title_addition ?></h1> <?php
 
 open_div( 'kommentar' );
   // open_span( '', '',
@@ -246,7 +263,7 @@ open_table( 'list' );
     open_th( '', "title='{$desc}'", $content );
   }
 
-  $dienste = sql_dienste();
+  $dienste = sql_dienste($filter_since_period, $order);
 
   $currentDate = "initial";
   $dienst = current( $dienste );
@@ -313,4 +330,17 @@ open_table( 'list' );
   }
 close_table();
 
+medskip();
+
+open_div( 'center' );
+  open_tag("button", "button", "id='loadMoreButton'", "⇩⇩⇩ Mehr laden... ⇩⇩⇩");
+close_div();
+
 ?>
+<script>
+    document.getElementById('loadMoreButton').addEventListener(
+      'click',
+      // move the limit roughly 6m back in time (-15768576s)
+      (event) => { loadMore('since', <?php echo $since ?>, -15768576); }
+    );
+</script>


### PR DESCRIPTION
Some views used to eagerly load the complete data from the very beginning where it might rarely be necessary. In these cases, the period of time is now restricted and can be exntended using a simple "load more" button at the bottom of the view.

For now, it is only implemented for orders and historical jobs.